### PR TITLE
Fix QLabel lookups

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,11 +34,11 @@ MainWindow::MainWindow(QWidget* parent)
     m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     m_table->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-    // Метрики (берём по objectName из .ui)
-    m_lblN    = ui->findChild<QLabel*>("lblN");
-    m_lblH    = ui->findChild<QLabel*>("lblH");
-    m_lblHmax = ui->findChild<QLabel*>("lblHmax");
-    m_lblHref = ui->findChild<QLabel*>("lblHref");
+    // Метрики (указатели приходят напрямую из ui)
+    m_lblN    = ui->lblN;
+    m_lblH    = ui->lblH;
+    m_lblHmax = ui->lblHmax;
+    m_lblHref = ui->lblHref;
 
     // Начальные значения
     if (m_lblN)    m_lblN->setText("–");


### PR DESCRIPTION
## Summary
- use generated QLabel members from the UI instead of calling findChild

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6795b7c38832f9adccfbef800d52f